### PR TITLE
Add option mail_only_on_changes

### DIFF
--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -1,11 +1,14 @@
 # Class for managing aide's cron job.
 class aide::cron (
   $aide_path,
+  $cat_path,
+  $rm_path,
   $conf_path,
   $minute,
   $hour,
   $nocheck,
   $mailto,
+  $mail_only_on_changes,
 ) {
 
   if $nocheck == true {
@@ -15,12 +18,22 @@ class aide::cron (
   }
 
   if $mailto != undef {
-    cron { 'aide':
-      ensure  => $cron_ensure,
-      command => "${aide_path} --config ${conf_path} --check | /usr/bin/mail -s \"\$(hostname) - AIDE Integrity Check\" ${mailto}",
-      user    => 'root',
-      hour    => $hour,
-      minute  => $minute,
+    if $mail_only_on_changes {
+      cron { 'aide':
+        ensure  => $cron_ensure,
+        command => "LOG=$(mktemp) && ${aide_path} --config ${conf_path} --check > \$LOG 2>&1 || ${cat_path} -v \$LOG | /usr/bin/mail -E -s \"\$(hostname) - AIDE Integrity Check\" ${mailto}; ${rm_path} -f \$LOG",
+        user    => 'root',
+        hour    => $hour,
+        minute  => $minute,
+      }
+    } else {
+      cron { 'aide':
+        ensure  => $cron_ensure,
+        command => "${aide_path} --config ${conf_path} --check | /usr/bin/mail -s \"\$(hostname) - AIDE Integrity Check\" ${mailto}",
+        user    => 'root',
+        hour    => $hour,
+        minute  => $minute,
+      }
     }
   } else {
     cron { 'aide':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,19 +1,20 @@
 # the aide class manages some the configuration of aide
 class aide (
-  $package         = $aide::params::package,
-  $version         = $aide::params::version,
-  $conf_path       = $aide::params::conf_path,
-  $db_path         = $aide::params::db_path,
-  $db_temp_path    = $aide::params::db_temp_path,
-  $hour            = $aide::params::hour,
-  $minute          = $aide::params::minute,
-  $gzip_dbout      = $aide::params::gzip_dbout,
-  $aide_path       = $aide::params::aide_path,
-  $aide_log        = $aide::params::aide_log,
-  $syslogout       = $aide::params::syslogout,
-  $config_template = $aide::params::config_template,
-  $nocheck         = $aide::params::nocheck,
-  $mailto          = $aide::params::mailto,
+  $package              = $aide::params::package,
+  $version              = $aide::params::version,
+  $conf_path            = $aide::params::conf_path,
+  $db_path              = $aide::params::db_path,
+  $db_temp_path         = $aide::params::db_temp_path,
+  $hour                 = $aide::params::hour,
+  $minute               = $aide::params::minute,
+  $gzip_dbout           = $aide::params::gzip_dbout,
+  $aide_path            = $aide::params::aide_path,
+  $aide_log             = $aide::params::aide_log,
+  $syslogout            = $aide::params::syslogout,
+  $config_template      = $aide::params::config_template,
+  $nocheck              = $aide::params::nocheck,
+  $mailto               = $aide::params::mailto,
+  $mail_only_on_changes = $aide::params::mail_only_on_changes,
 ) inherits aide::params {
 
   package { $package:
@@ -21,13 +22,16 @@ class aide (
   }
 
   -> class  { '::aide::cron':
-      aide_path => $aide_path,
-      minute    => $minute,
-      hour      => $hour,
-      nocheck   => $nocheck,
-      mailto    => $mailto,
-      conf_path => $conf_path,
-      require   => Package[$package],
+      aide_path            => $aide_path,
+      cat_path             => $aide::params::cat_path,
+      rm_path              => $aide::params::rm_path,
+      minute               => $minute,
+      hour                 => $hour,
+      nocheck              => $nocheck,
+      mailto               => $mailto,
+      mail_only_on_changes => $mailto,
+      conf_path            => $conf_path,
+      require              => Package[$package],
     }
 
   -> class  { '::aide::config':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,30 +1,37 @@
 # aide::params sets the default values for parameters.
 class aide::params {
-  $package         = 'aide'
-  $mailto          = undef
-  $version         = 'latest'
-  $db_path         = '/var/lib/aide/aide.db'
-  $db_temp_path    = '/var/lib/aide/aide.db.new'
-  $gzip_dbout      = 'no'
-  $hour            = 0
-  $minute          = 0
-  $aide_log        = '/var/log/aide/aide.log'
-  $syslogout       = true
-  $config_template = 'aide/aide.conf.erb'
-  $cron_template   = 'aide/cron.erb'
-  $nocheck         = false
+  $package              = 'aide'
+  $mailto               = undef
+  $mail_only_on_changes = false
+  $version              = 'latest'
+  $db_path              = '/var/lib/aide/aide.db'
+  $db_temp_path         = '/var/lib/aide/aide.db.new'
+  $gzip_dbout           = 'no'
+  $hour                 = 0
+  $minute               = 0
+  $aide_log             = '/var/log/aide/aide.log'
+  $syslogout            = true
+  $config_template      = 'aide/aide.conf.erb'
+  $cron_template        = 'aide/cron.erb'
+  $nocheck              = false
 
   case $::osfamily {
     'Debian': {
       $aide_path = '/usr/bin/aide'
+      $cat_path  = '/bin/cat'
+      $rm_path   = '/bin/rm'
       $conf_path = '/etc/aide/aide.conf'
     }
     'Redhat': {
       $aide_path = '/usr/sbin/aide'
+      $cat_path  = '/usr/bin/cat'
+      $rm_path   = '/usr/bin/rm'
       $conf_path = '/etc/aide.conf'
     }
     default: {
       $aide_path = '/usr/sbin/aide'
+      $cat_path  = '/usr/bin/cat'
+      $rm_path   = '/usr/bin/rm'
       $conf_path = '/etc/aide.conf'
       #fail("The ${module_name} module is not supported on an ${::osfamily} based system.")
     }


### PR DESCRIPTION
If mail_only_on_changes is set to true, mails are only sent if changes are detected by AIDE. By default this flag is set to false.