### PR TITLE
Implement init_timeout.

### DIFF
--- a/manifests/firstrun.pp
+++ b/manifests/firstrun.pp
@@ -4,11 +4,13 @@ class aide::firstrun (
   $conf_path,
   $db_temp_path,
   $db_path,
+  $init_timeout,
 ) {
 
   exec { 'aide init':
     command     => "${aide_path} --init --config ${conf_path}",
     user        => 'root',
+    timeout     => $init_timeout,
     refreshonly => true,
     subscribe   => Concat['aide.conf'],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class aide (
   $nocheck              = $aide::params::nocheck,
   $mailto               = $aide::params::mailto,
   $mail_only_on_changes = $aide::params::mail_only_on_changes,
+  $init_timeout         = $aide::params::init_timeout,
 ) inherits aide::params {
 
   package { $package:
@@ -50,6 +51,7 @@ class aide (
       conf_path    => $conf_path,
       db_temp_path => $db_temp_path,
       db_path      => $db_path,
+      init_timeout => $init_timeout,
       require      => Package[$package],
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,7 @@ class aide::params {
   $config_template      = 'aide/aide.conf.erb'
   $cron_template        = 'aide/cron.erb'
   $nocheck              = false
+  $init_timeout         = 300
 
   case $::osfamily {
     'Debian': {


### PR DESCRIPTION
Allows to adjust timeout of the "aide --init" run.
Puppet default exec timeout is 300 (which is also kept),
but this may be insufficient for more complex aide DBs.

Signed-off-by: Oliver Freyermuth <o.freyermuth@googlemail.com>